### PR TITLE
SP-857 - Move to the v3 resource which uses the rest API 

### DIFF
--- a/github_repository.tf
+++ b/github_repository.tf
@@ -52,7 +52,7 @@ resource "github_branch_default" "default" {
   branch     = var.default_branch_name
 }
 
-resource "github_branch_protection" "repository_master" {
+resource "github_branch_protection_v3" "repository_main" {
   count = var.branch_protection_enabled == true ? 1 : 0
 
   repository_id    = github_repository.repository.node_id

--- a/github_teams.tf
+++ b/github_teams.tf
@@ -13,7 +13,7 @@ resource "github_team_repository" "admin_team_access" {
 }
 
 resource "github_team_repository" "developer_access" {
-  count      = var.admin_team_only ? 0 : 1
+  count      = var.developer_team == "" ? 0 : 1
   team_id    = var.developer_team
   repository = github_repository.repository.name
   permission = "maintain"


### PR DESCRIPTION
Switches to `github_branch_protection_v3` over `github_branch_protection`

`github_branch_protection_v3` uses the github REST API where as `github_branch_protection` uses the github GraphQL API