### PR TITLE
Add the workflow option for pages declaration #patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,6 @@ jobs:
           PRERELEASE: ${{ !startsWith(env.BRANCH_NAME, 'main') }}
           RELEASE_BRANCHES: main
           WITH_V: true
+      - name: Summary
+        run: |
+          echo "Tag: $${{ steps.bump_version.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,21 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ---
-    repos:
-      - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v2.0.0
-        hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: check-yaml
-      - repo: git://github.com/antonbabenko/pre-commit-terraform
-        rev: v1.44.0
-        hooks:
-          - id: terraform_fmt
-          - id: terraform_docs_without_aggregate_type_defaults
+repos:
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.83.2
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs_without_aggregate_type_defaults
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: trailing-whitespace # trims trailing whitespace.
+    - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline.
+    - id: check-yaml # checks yaml files for parseable syntax.
+    - id: detect-private-key # detects the presence of private keys.
+    - id: mixed-line-ending # replaces or checks mixed line ending.
+      args: [ "--fix=auto" ]
+    - id: no-commit-to-branch
+      args:
+      - --branch=main

--- a/github_repository.tf
+++ b/github_repository.tf
@@ -24,8 +24,9 @@ resource "github_repository" "repository" {
 
     content {
       source {
-        branch = var.pages.branch
-        path   = try(var.pages.path, "/")
+        branch    = var.pages.branch
+        path      = try(var.pages.path, "/")
+        workflow  = try(var.pages.workflow, "legacy")
       }
       cname = try(var.pages.cname, null)
     }

--- a/github_repository.tf
+++ b/github_repository.tf
@@ -24,9 +24,9 @@ resource "github_repository" "repository" {
 
     content {
       source {
-        branch    = var.pages.branch
-        path      = try(var.pages.path, "/")
-        workflow  = try(var.pages.workflow, "legacy")
+        branch     = var.pages.branch
+        path       = try(var.pages.path, "/")
+        build_type = try(var.pages.build_type, "legacy")
       }
       cname = try(var.pages.cname, null)
     }
@@ -88,4 +88,3 @@ resource "github_actions_secret" "repository_secret" {
 
 
 }
-

--- a/github_repository.tf
+++ b/github_repository.tf
@@ -26,7 +26,6 @@ resource "github_repository" "repository" {
       source {
         branch = var.pages.branch
         path   = try(var.pages.path, "/")
-
       }
       build_type = try(var.pages.build_type, "legacy")
       cname      = try(var.pages.cname, null)

--- a/github_repository.tf
+++ b/github_repository.tf
@@ -24,11 +24,12 @@ resource "github_repository" "repository" {
 
     content {
       source {
-        branch     = var.pages.branch
-        path       = try(var.pages.path, "/")
-        build_type = try(var.pages.build_type, "legacy")
+        branch = var.pages.branch
+        path   = try(var.pages.path, "/")
+
       }
-      cname = try(var.pages.cname, null)
+      build_type = try(var.pages.build_type, "legacy")
+      cname      = try(var.pages.cname, null)
     }
   }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 5.0"
+      version = "~> 5.27"
     }
   }
   required_version = ">= 1.0.0"


### PR DESCRIPTION
- Add in `build_type` option for pages - default it to `legacy` for older repos with pages
- update provider requirements to v5 that has this new option ([v5.27.0](https://github.com/integrations/terraform-provider-github/releases/tag/v5.27.0))
- Update pre-commit versions and setup
- Update action to push the created tag to the summary for ease
